### PR TITLE
consider deprecated shipping method

### DIFF
--- a/lib/spree/retailops/rop_order_helper.rb
+++ b/lib/spree/retailops/rop_order_helper.rb
@@ -142,7 +142,10 @@ module Spree
         # Where entire shipping fee is removed from order if 
         # last unshipped line_item is canceled.
         if removed && !method && @order.shipments.present? && !@order.shipments.unshipped.present?
-          method = Spree::ShippingMethod.first
+          method = @order.completed_at < '2015-07-14 15:20 PDT'.to_time ? 
+          Spree::ShippingMethod.first : Spree::ShippingMethod.find_by_name("Standard Shipping")
+
+          Rails.logger.error "Shipping method changed to #{method.name} on #{@order.number}"
         end
 
         return method && method.calculator.compute(Spree::Stock::Package.new( stock_location, @order, contents ))


### PR DESCRIPTION
@quetzaluz @schwartzdev 

This is relatively rare case and probably very unlikely to happen,
but still needs this fix.

Read the comment to see what this case was for

```
# If the shipment that was just deleted was the last unshipped shipment
        # Recalculate the ship cost using standard shipping method
        # This resolves https://github.com/dotandbo/dotandbo-spree/issues/3857
        # Where entire shipping fee is removed from order if 
        # last unshipped line_item is canceled.
```
