### PR TITLE
fix bug caused by removed 'unshipped' scope

### DIFF
--- a/lib/spree/retailops/rop_order_helper.rb
+++ b/lib/spree/retailops/rop_order_helper.rb
@@ -141,7 +141,7 @@ module Spree
         # This resolves https://github.com/dotandbo/dotandbo-spree/issues/3857
         # Where entire shipping fee is removed from order if 
         # last unshipped line_item is canceled.
-        if removed && !method && @order.shipments.present? && !@order.shipments.unshipped.present?
+        if removed && !method && @order.shipments.present? && @order.shipments.where('state != ?','shipped').empty?
           method = @order.completed_at < '2015-07-14 15:20 PDT'.to_time ? 
           Spree::ShippingMethod.first : Spree::ShippingMethod.find_by_name("Standard Shipping")
 


### PR DESCRIPTION
@schwartzdev @sankalpk  

This was the root cause of https://github.com/dotandbo/dotandbo-spree/issues/4425, where cancellation did not flow from R.O to Spree.

"Unshipped" scope was removed during the spree upgrade.
